### PR TITLE
Correction to regex to correctly match variable-value pairs in certutil output

### DIFF
--- a/scripts/Install-ADFS.ps1
+++ b/scripts/Install-ADFS.ps1
@@ -115,7 +115,7 @@ try {
                         Write-Host $line
                         $entry = New-Object -TypeName PSObject
                     }
-                    if ($line -match "  (?<variable>[\w\s]+):\s+``(?<value>.*)'") {
+                    if ($line -match "  (?<variable>[\w\s]+):\s+`"(?<value>.*)`"") {
                         # Populate CA entry
                         $entry | Add-Member -MemberType NoteProperty -Name $matches.variable -Value $matches.value -Force
                     }


### PR DESCRIPTION
Line 118 in the script Install-ADFS.ps1 contains a regex that does not match the variable-value pairs in the outputr of the certutil.exe -dump command.
This correction fixes the regex.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.