### PR TITLE
Adding Domain Members to SG

### DIFF
--- a/templates/wap-adfs.template
+++ b/templates/wap-adfs.template
@@ -1035,7 +1035,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 3389
           ToPort: 3389
-          CidrIp: !Ref 'DomainMemberSGID'
+          SourceSecurityGroupId: !Ref 'DomainMemberSGID'
   ADFSSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -1057,4 +1057,4 @@ Resources:
         - IpProtocol: tcp
           FromPort: 3389
           ToPort: 3389
-          CidrIp: !Ref 'DomainMemberSGID'
+          SourceSecurityGroupId: !Ref 'DomainMemberSGID'

--- a/templates/wap-adfs.template
+++ b/templates/wap-adfs.template
@@ -1032,6 +1032,10 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: '0.0.0.0/0'
+        - IpProtocol: tcp
+          FromPort: 3389
+          ToPort: 3389
+          CidrIp: !Ref 'DomainMemberSGID'
   ADFSSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -1050,3 +1054,7 @@ Resources:
           FromPort: 445
           ToPort: 445
           CidrIp: !Ref 'VPCCIDR'
+        - IpProtocol: tcp
+          FromPort: 3389
+          ToPort: 3389
+          CidrIp: !Ref 'DomainMemberSGID'


### PR DESCRIPTION
*Description of changes:*
Making so domain members can RDP into each other.  

*Taskcat Output:*

[taskcat_outputs.zip](https://github.com/aws-quickstart/quickstart-microsoft-wapadfs/files/5889418/taskcat_outputs.zip)

[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-GIJ48K1PJ8T9
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-Y74STJVJ9KZ0
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-FDB75N8G02Y3
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-UBBV2LY3SHEI
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-1NDIF0P41FGDB
[INFO   ] : ┣ region: ap-northeast-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-HCSJYBOMQ990
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-7ZIDPW1V2P1
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-CG7F6673KPXQ
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-K1V1WRWYCCZA
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-1LZG1J4NR0PJ3
[INFO   ] : ┣ region: ap-southeast-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-2GHBX3BVCW2G
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-98805RIR0UAP
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-U1XFKOO60UXN
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-S32RJMTZZST
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-INO8G1OZZ779
[INFO   ] : ┣ region: ap-southeast-2
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-M4ZSU6NBDKVN
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-QFH29TKYERPQ
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-TID563KK8AAA
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-UHJN8YYS6M4
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-MMKCYYSF0H9N
[INFO   ] : ┣ region: ca-central-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-ZMATXX53U0XL
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-G874LXWHT54G
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-Z9N3DQOVZT5D
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-15N13M1LLXGTZ
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-1LO7QX6NS1H2X
[INFO   ] : ┣ region: eu-central-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-1D3RU0WVKF26A
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-194H7MPNJX115
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-VAN6NB6WUZFH
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-1QHI8345W0F18
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-1K0UV7GJMF7VK
[INFO   ] : ┣ region: eu-west-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-LNHJPPY55440
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-1R518CP18TDLQ
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-4BSAE3GQ5J13
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-SLV3MLITTGCM
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-TBRZMA7J6TJ8
[INFO   ] : ┣ region: eu-west-2
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-1MELTBT9HG87Z
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-17A3M34GQVVHT
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-CLSDJR2UM7FE
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-OFX3DSU63YE3
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-P0X76GKIXSYM
[INFO   ] : ┣ region: us-west-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-VPCStack-HH5BQ8KU1425
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-ADStack-1FTN7DLVRP9VZ
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae261-WAPADFSStack-9FROQ6ZH3BTT
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2619-EntCAStack-1JMRUTSQIY6KJ
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-19fe3d72268c4a4589ab0b9093ae2-OneTierCAStack-1BLUAWT7G4KX5
[INFO   ] : ┣ region: us-west-2
[INFO   ] : ┗ status: CREATE_COMPLETE



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
