### PR TITLE
Encrypting EBS Volumes with Defined Key

### DIFF
--- a/templates/wap-adfs.template
+++ b/templates/wap-adfs.template
@@ -31,6 +31,7 @@ Metadata:
         Parameters:
           - KeyPairName
           - LatestAmiId
+          - EbsEncryptionKmsKeyId
       - Label:
           default: Microsoft Active Directory Domain Services configuration
         Parameters:
@@ -78,6 +79,8 @@ Metadata:
         default: Domain member security group ID
       DomainNetBIOSName:
         default: Domain NetBIOS name
+      EbsEncryptionKmsKeyId:
+        default: KMS Key for EBS Encryption
       KeyPairName:
         default: Key pair name
       LatestAmiId:
@@ -119,7 +122,6 @@ Parameters:
     Description: Type of Active Directory the WAP / ADFS deployment will be integrated with, AWS Managed Microsoft AD or Self Managed AD
     Type: String
   DomainAdminUserSecret:
-    Default: arn:${AWS::Partition}:secretsmanager:us-west-2:820097935833:secret:DefaultCreds-IsuSDO
     Description: ARN for the Administrator credentials Secret with "username" and "password" key pairs. This account must be a member of Domain Admins with Self Managed directories or a member of AWS Delegated Administrators with AWS Managed Microsoft AD.
     Type: String
   DomainController1IP:
@@ -148,6 +150,10 @@ Parameters:
     Description: NetBIOS name of the domain the WAP / ADFS instances will join (up to 15 characters) for users of earlier versions of Windows e.g. CORP
     MaxLength: '15'
     MinLength: '1'
+    Type: String
+  EbsEncryptionKmsKeyId:
+    Default: alias/aws/ebs
+    Description: The identifier of the AWS KMS key to use for Amazon EBS encryption. You can specify the KMS key using any of the following; Key ID, Key alias, Key ARN, Alias ARN
     Type: String
   KeyPairName:
     Description: Public/private key pairs allow you to securely connect to your instance after it launches
@@ -483,7 +489,7 @@ Resources:
 
                   $S3BucketName = '{{ QSS3BucketName }}'
                   $S3KeyPrefix = '{{ QSS3KeyPrefix }}'
-
+                  $S3BucketRegion = '{{QSS3BucketRegion}}'
 
                   $CustomModules = @(
                       'Module-WAPADFS.psd1',
@@ -513,7 +519,7 @@ Resources:
                   Write-Output 'Downloading ADFS PowerShell Module'
                   Foreach ($CustomModule in $CustomModules) {
                       Try {
-                          $Null = Read-S3Object -BucketName $S3BucketName -Key "$($S3KeyPrefix)/scripts/Modules/Module-WAPADFS/$CustomModule" -File "C:\AWSQuickstart\Module-WAPADFS\$CustomModule"
+                          $Null = Read-S3Object -BucketName $S3BucketName -Key "$($S3KeyPrefix)/scripts/Modules/Module-WAPADFS/$CustomModule" -File "C:\AWSQuickstart\Module-WAPADFS\$CustomModule" -Region $S3BucketRegion
                       } Catch [System.Exception] {
                           Write-Output "Failed to read and download $CustomModule.Name from S3 $_"
                           Exit 1
@@ -736,6 +742,7 @@ Resources:
             VolumeSize: 60
             VolumeType: gp3
             Encrypted: true
+            KmsKeyId: !Ref 'EbsEncryptionKmsKeyId'
             DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'WAPSecurityGroup'
@@ -759,6 +766,7 @@ Resources:
             VolumeSize: 60
             VolumeType: gp3
             Encrypted: true
+            KmsKeyId: !Ref 'EbsEncryptionKmsKeyId'
             DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'WAPSecurityGroup'
@@ -782,6 +790,7 @@ Resources:
             VolumeSize: 60
             VolumeType: gp3
             Encrypted: true
+            KmsKeyId: !Ref 'EbsEncryptionKmsKeyId'
             DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'ADFSSecurityGroup'
@@ -813,6 +822,7 @@ Resources:
             VolumeSize: 60
             VolumeType: gp3
             Encrypted: true
+            KmsKeyId: !Ref 'EbsEncryptionKmsKeyId'
             DeleteOnTermination: true
       SecurityGroupIds:
         - !Ref 'ADFSSecurityGroup'


### PR DESCRIPTION
*Description of changes:*

I added a new optional parameter to allow customers to set their KMS key for EBS encryption.

*Taskcat Output:* 

[taskcat_outputs.zip](https://github.com/aws-quickstart/quickstart-microsoft-wapadfs/files/6918309/taskcat_outputs.zip)

[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-VPCStack-1Q4O85BZ58OFR
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-ADStack-2VA3ZWDJ80CW
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234-WAPADFSStack-HMKL42Z1LO2G
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-EntCAStack-1TBLX6JOCRV17
[INFO   ] : ┣ region: ap-northeast-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-VPCStack-1D9XZKZVHC48D
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-ADStack-15XPESSXN9WUW
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234-WAPADFSStack-B1XU4N3JKQ57
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-EntCAStack-1KZJDV2WWI7JE
[INFO   ] : ┣ region: ap-southeast-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-VPCStack-1SCUV2JXNK2VL
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-ADStack-1RU7QZUGCSSMA
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234-WAPADFSStack-ODC5G1NO26XX
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-EntCAStack-4GFF2XAOVDZD
[INFO   ] : ┣ region: ap-southeast-2
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-VPCStack-1PKHIZNW7WQZY
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-ADStack-1D8LNBIS4PSF2
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234-WAPADFSStack-1DUAU93Y8LRUP
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-EntCAStack-1G0MXBQY9EEUI
[INFO   ] : ┣ region: ca-central-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-VPCStack-1I4P1HNMELWHM
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-ADStack-1P5GQUICC5WSC
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234-WAPADFSStack-62ZP5QFHUHR3
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-EntCAStack-1PYRKWTV0HHLK
[INFO   ] : ┣ region: eu-central-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-VPCStack-1TD52AJQI5LA0
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-ADStack-KKU1RX1ZYEAF
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234-WAPADFSStack-AF22OB2MMXZD
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-EntCAStack-1BBRH0PURNR56
[INFO   ] : ┣ region: eu-west-1
[INFO   ] : ┗ status: CREATE_COMPLETE
[INFO   ] : ┏ stack Ⓜ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-VPCStack-1FVH1R8WXADYE
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-ADStack-IUD1S6BQDXK9
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234-WAPADFSStack-12KLU4SK35QTQ
[INFO   ] : ┣ stack Ⓝ tCaT-quickstart-microsoft-wapadfs-wapadfs-221886aeb7a44a3990623695f06a234b-EntCAStack-YUR8TSJIECPY
[INFO   ] : ┣ region: eu-west-2
[INFO   ] : ┗ status: CREATE_COMPLETE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
